### PR TITLE
Add build guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
 # Ucupaint Wiki
 
 [Click here](https://ucupumar.github.io/ucupaint-wiki/) to read Ucupaint wiki.
+
+## Build guide
+
+The docs are built and deployed automatically using GitHub actions. However if you want to contribute and test changes locally, you can build the docs manually as such:
+
+1. Get [Python](https://www.python.org/)
+2. Enter the project folder
+3. Run `pip install -r requirements.txt`
+4. Run `mkdocs build` to build the docs
+5. You can find the docs in a newly created folder called _"site"_


### PR DESCRIPTION
When contributing I found it useful to build the site locally and test links and such. It's cool to have a little guide for people who might not be familiar with mkdocs.

Let me know what you think!