### PR TITLE
Typos, sections names

### DIFF
--- a/docs/01.00.quick-setup.md
+++ b/docs/01.00.quick-setup.md
@@ -31,7 +31,7 @@ If you open the shader editor, what's actually happening is the quick setup is c
 |:--:|
 |What quick setup actually creates| {align=center}
 
-## Collapse/Uncollapse Menu
+## Expand/Collapse Menu
 
 Please notice that if you see a small triangle beside an icon, it means you can expand or collapse the extra menu, you can see it on the example gif below.
 

--- a/docs/01.01.channel.md
+++ b/docs/01.01.channel.md
@@ -38,7 +38,7 @@ Now the popup appears, if you already decided to connect it to principled bsdf, 
 |:--:|
 |Creating new channel| {align=center, width=100%}
 
-You can see that the Ucupaint node will have a new input and output sockets after you created a new channel.
+You can see that the Ucupaint node will have new input and output sockets after you created a new channel.
 
 ## Channel Types
 There are three types of channels in Ucupaint, they are RGB, Value, and Normal.

--- a/docs/01.02.layer.md
+++ b/docs/01.02.layer.md
@@ -93,9 +93,11 @@ You can use Blender's generated textures as a layer, for example Noise, Magic, B
 
 You can use a baked texture as a layer, for example AO, Cavity, Bevel. Be aware that the baking process may take a while to finish depending on your system and settings.
 
+## Layer Parameters And Options
+
 ### Layer Vector
 
-By default, layer will use a UVMap as vector input, but you can change it to other vector type like generated.
+By default, a layer will use a UVMap as vector input, but you can change it to another vector type like Generated.
 
 |![[pic: vector options]](source/03.layer.09.png)|
 |:--:|
@@ -111,7 +113,7 @@ You can transform your vector using this UI.
 |:--:|
 |Vector transformation options| {align=center}
 
-Be aware you can't transform image atlas layer since it shares image with other layers/masks.
+Be aware you can't transform image atlas layer in this way since it shares image with other layers/masks.
 
 ### Change layer type
 

--- a/docs/01.04.mask.md
+++ b/docs/01.04.mask.md
@@ -22,7 +22,7 @@ Let's choose an image mask type for example, you'll be given these options:
 |:--:|
 |New image mask dialog box| {align=center}
 
-Choose white as the base color of the mask image, now you can paint black to the mask the layer, as demonstrated below.
+Choose white as the base color of the mask image, now you can paint black to mask the layer, as demonstrated below.
 
 |![type:video](source/05.layer-mask.04.mp4)|
 |:--:|

--- a/docs/01.05.modifier.md
+++ b/docs/01.05.modifier.md
@@ -27,7 +27,7 @@ With the RGB curve modifier applied, you can adjust the output of the color chan
 
 ## Modifier types
 
-- Invert: will invert selectable rgb and alpha values
+- Invert: will invert selected rgb and alpha values
 - RGB to Intensity: will convert the rgb of your layer to intensity/alpha and replace layer rgb values themselves with a single color.
 - Intensity to RGB: will convert the alpha of your layer to rgb and replace layer alpha value itself with a solid value
 - Color Ramp: will map the layer rgb values to a color ramp


### PR DESCRIPTION
Last PR 🙂

- Typos
- Changed the "Collapse/Uncollapse" heading to "Expand/Collapse", as I think that's a way more common expression
- Added a level 2 "Layer Parameters And Options" heading on the layer page to separate parameter descriptions from layer type descriptions

Let me know if it's fine.
Thanks!