### PR TITLE
Update mkdocs.yml

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,6 +32,8 @@ plugins:
         display: "block"
         margin: "auto"
 markdown_extensions:
+  - toc:
+      permalink: true
   - admonition
   - pymdownx.details
   - pymdownx.superfences


### PR DESCRIPTION
This allows anchored links to specific headings within a page. 

<img width="815" height="263" alt="image" src="https://github.com/user-attachments/assets/1ca5564c-fd07-4e83-a3ae-083bf28c62bd" />

This can help to refer to a specific section of the documentation more accurate because headings become part of the url as well:

<img width="535" height="47" alt="image" src="https://github.com/user-attachments/assets/9562f508-c740-4fce-b4a6-b33c9ed36c69" />
